### PR TITLE
Add sales dashboard template

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -6,11 +6,13 @@ from .views import (
     categoria_list, categoria_create, categoria_update, categoria_delete,
     stock_list, stock_create, stock_update, stock_delete,
     venta_list, venta_create, venta_update, venta_delete,
-    ventas_data 
+    ventas_data,
+    dashboard,
 )
 
 urlpatterns = [
     path('', home, name='home'),
+    path('dashboard/', dashboard, name='dashboard'),
 
     # Libro
     path('libros/', libro_list, name='libro_list'),
@@ -42,5 +44,7 @@ urlpatterns = [
     path('ventas/nuevo/', venta_create, name='venta_create'),
     path('ventas/<int:pk>/editar/', venta_update, name='venta_update'),
     path('ventas/<int:pk>/eliminar/', venta_delete, name='venta_delete'),
+
+    # API
+    path('api/ventas_data/', ventas_data, name='ventas_data'),
 ]
-path('api/ventas_data/', ventas_data, name='ventas_data'),

--- a/core/views.py
+++ b/core/views.py
@@ -41,6 +41,10 @@ def home(request):
         'chart_totals': chart_totals,
     })
 
+def dashboard(request):
+    """Simple view to render the sales dashboard."""
+    return render(request, 'dashboard.html')
+
 def libro_list(request):
     libros = Libro.objects.all()
     return render(request, 'libro_list.html', {'libros': libros})

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Libreria{% endblock %}</title>
+    {% block extra_head %}{% endblock %}
+</head>
+<body>
+    {% block content %}{% endblock %}
+</body>
+</html>
+

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,47 @@
+{% extends 'base.html' %}
+
+{% block title %}Dashboard Ventas{% endblock %}
+
+{% block extra_head %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<style>
+    .chart-container{width:100%;max-width:600px;height:300px;margin:20px auto;}
+</style>
+{% endblock %}
+
+{% block content %}
+<h1>Dashboard de Ventas</h1>
+<div class="chart-container"><canvas id="barChart"></canvas></div>
+<div class="chart-container"><canvas id="lineChart"></canvas></div>
+<div class="chart-container"><canvas id="pieChart"></canvas></div>
+<script>
+let barChart,lineChart,pieChart;
+
+function initCharts(labels,data){
+    const barCtx=document.getElementById('barChart').getContext('2d');
+    const lineCtx=document.getElementById('lineChart').getContext('2d');
+    const pieCtx=document.getElementById('pieChart').getContext('2d');
+    barChart=new Chart(barCtx,{type:'bar',data:{labels:labels,datasets:[{label:'Ventas',data:data,backgroundColor:'rgba(54,162,235,0.5)',borderColor:'rgba(54,162,235,1)',borderWidth:1}]},options:{responsive:true,maintainAspectRatio:false}});
+    lineChart=new Chart(lineCtx,{type:'line',data:{labels:labels,datasets:[{label:'Ventas',data:data,borderColor:'rgba(255,99,132,1)',fill:false}]},options:{responsive:true,maintainAspectRatio:false}});
+    pieChart=new Chart(pieCtx,{type:'pie',data:{labels:labels,datasets:[{data:data,backgroundColor:labels.map((_,i)=>`hsl(${i*40%360},70%,70%)`)}]},options:{responsive:true,maintainAspectRatio:false}});
+}
+
+function updateCharts(labels,data){
+    if(!barChart){initCharts(labels,data);return;}
+    [barChart,lineChart,pieChart].forEach(chart=>{chart.data.labels=labels;chart.data.datasets[0].data=data;chart.update();});
+}
+
+async function loadData(){
+    try{
+        const res=await fetch('/api/ventas_data/');
+        if(!res.ok) return;
+        const d=await res.json();
+        updateCharts(d.fechas,d.totales);
+    }catch(e){console.error(e);}
+}
+
+loadData();
+setInterval(loadData,30000);
+</script>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- create `base.html` with basic blocks
- add new `dashboard.html` extending `base.html` showing bar, line and pie charts with auto reload
- expose dashboard view and API route in `urls.py`
- add simple view for dashboard

## Testing
- `python manage.py check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_687a7c450d408322bab6c0f5c3e9fe34